### PR TITLE
fix: latidude and longitude can be set (closes #373)

### DIFF
--- a/src/l10n/locales/en.ts
+++ b/src/l10n/locales/en.ts
@@ -13,8 +13,10 @@ export default {
     "Could not parse GeoJSON file": "Could not parse GeoJSON file",
     "Could not parse overlay radius. Please make sure it is in the format `<length> <unit>`.":
         "Could not parse overlay radius. Please make sure it is in the format `<length> <unit>`.",
-    "There was an error with the provided latitude and longitude. Using defaults.":
-        "There was an error with the provided latitude and longitude. Using defaults.",
+    "There was an error with the provided latitude. Using defaults.":
+        "There was an error with the provided latitude. Using defaults.",
+    "There was an error with the provided longitude. Using defaults.":
+        "There was an error with the provided longitude. Using defaults.",
 
     //loader.ts
     "There was an issue getting the image dimensions.":

--- a/src/l10n/locales/zh_CN.ts
+++ b/src/l10n/locales/zh_CN.ts
@@ -13,7 +13,9 @@ export default {
     "Could not parse GeoJSON file": "无法解析 GeoJSON 文件",
     "Could not parse overlay radius. Please make sure it is in the format `<length> <unit>`.":
         "无法解析覆盖半径. 请确保格式为 `<长度> <单位>`.",
-    "There was an error with the provided latitude and longitude. Using defaults.":
+    "There was an error with the provided latitude. Using defaults.":
+        "提供的纬度和经度有误. 使用默认值.",
+    "There was an error with the provided longitude. Using defaults.":
         "提供的纬度和经度有误. 使用默认值.",
 
     //loader.ts

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -1351,7 +1351,7 @@ export class LeafletRenderer extends MarkdownRenderChild {
     }> {
         let latitude = lat;
         let longitude = long;
-        let coords: [number, number] = [undefined, undefined];
+        const coords: [number, number] = [undefined, undefined];
         let zoomDistance, file;
         if (typeof coordinates == "string" && coordinates.length) {
             file = this.plugin.app.metadataCache.getFirstLinkpathDest(
@@ -1375,39 +1375,32 @@ export class LeafletRenderer extends MarkdownRenderChild {
             map.log(`Using supplied coordinates [${latitude}, ${longitude}]`);
         }
 
-        let err: boolean = false;
-        const convertedLatitude = Number(`${latitude}`?.split("%").shift());
-        const convertedLongitude = Number(`${longitude}`?.split("%").shift());
-        try {
-            coords = [convertedLatitude, convertedLongitude];
-        } catch (e) {
-            err = true;
-        }
+        let convertedLatitude: number;
+        let convertedLongitude: number;
 
-        if (
-            (!isNaN(convertedLatitude) || !isNaN(convertedLongitude)) &&
-            (err || isNaN(coords[0]) || isNaN(coords[1]))
-        ) {
-            new Notice(
-                t(
-                    "There was an error with the provided latitude and longitude. Using defaults."
-                )
-            );
+        try {
+            convertedLatitude = Number(`${latitude}`?.split("%", 1)[0]);
+        } catch (error) {
+            new Notice(t("There was an error with the provided latitude. Using default."));
         }
-        if (map.type != "real") {
-            if (!isNaN(convertedLatitude) || isNaN(coords[0])) {
-                coords[0] = 50;
-            }
-            if (!isNaN(convertedLongitude) || isNaN(coords[1])) {
-                coords[1] = 50;
-            }
+        if (!isNaN(convertedLatitude)) {
+            coords[0] = convertedLatitude;
+        } else if (map.type === "real") {
+            coords[0] = this.plugin.data.lat;
         } else {
-            if (!isNaN(convertedLatitude) || isNaN(coords[0])) {
-                coords[0] = this.plugin.data.lat;
-            }
-            if (!isNaN(convertedLongitude) || isNaN(coords[1])) {
-                coords[1] = this.plugin.data.long;
-            }
+            coords[0] = 50;
+        }
+        try {
+            convertedLongitude = Number(`${longitude}`?.split("%", 1)[0]);
+        } catch (error) {
+            new Notice(t("There was an error with the provided longitude. Using default."));
+        }
+        if (!isNaN(convertedLongitude)) {
+            coords[1] = convertedLongitude;
+        } else if (map.type === "real") {
+            coords[1] = this.plugin.data.long;
+        } else {
+            coords[1] = 50;
         }
 
         return { coords, zoomDistance, file };


### PR DESCRIPTION
This fixes the inverted NaN-check to see if coordinates are valid, and makes the logic for choosing coodrinates or defaults a bit more robust. They can now fail independently of each other, so that an error in lat doesn't prevent long from being set.

I've tested the code locally and it "works on my machine".

The zh_CN translations still need to be adjusted slightly, for now I'm still using the old warning that didn't differentiate between lat/long. - @Wanxp could you maybe help me here since you did the initial translations? I'd appreciate if you could e.g. send me the two new strings, then I could finalise the PR.