### PR TITLE
fix: expand local links for obsidian's hover-preview (closes #361)

### DIFF
--- a/src/layer/marker.ts
+++ b/src/layer/marker.ts
@@ -484,7 +484,9 @@ export class Marker extends Layer<DivIconMarker> {
                 );
             }
         }
-        this._link = x;
+        this._link = x.startsWith("#")
+            ? this.map.options.context + x
+            : x;
         if (this.target) this.target.text = x;
         if (this.popup && this.displayed && this.tooltip === "always")
             this.popup.open(this.target.display);


### PR DESCRIPTION
This adds the current note's path to a marker's link, if the link would otherwise start with a `#`, ie if it links to an anchor (paragraph or ^anchor) in the local file.

The popup generated by leaflet is not affected, only the hover-preview showing the linked note.

closes #361 