### PR TITLE
fix: clean up settings

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -76,8 +76,7 @@
 }
 
 .marker-creation-modal .icon-display {
-    margin-block: 1em auto;
-    line-height: 0;
+    padding: 1rem;
 }
 
 .marker-creation-modal .icon-display canvas {

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -75,12 +75,12 @@
     border-top: none;
 }
 
-.icon-display {
+.marker-creation-modal .icon-display {
     margin-block: 1em auto;
     line-height: 0;
 }
 
-.icon-display canvas {
+.marker-creation-modal .icon-display canvas {
     width: 100%;
 }
 
@@ -116,16 +116,16 @@
 
 /** Invalid Setting */
 
-.unset-align-items {
+.leaflet-settings-modal .unset-align-items {
     align-items: unset;
 }
 
-.has-invalid-message {
+.leaflet-settings-modal .has-invalid-message {
     flex-grow: unset;
     flex-flow: column nowrap;
 }
 
-input.is-invalid {
+.leaflet-settings-modal input.is-invalid {
     border-color: #dc3545 !important;
     background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='%23dc3545'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23dc3545' stroke='none'/%3e%3c/svg%3e");
     background-repeat: no-repeat;
@@ -133,7 +133,7 @@ input.is-invalid {
     background-size: calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
 }
 
-.invalid-feedback {
+.leaflet-settings-modal .invalid-feedback {
     display: block;
     width: 100%;
     margin-top: 0.25rem;
@@ -669,5 +669,5 @@ input.is-invalid {
 }
 
 .leaflet-marker-icon svg {
-  filter: drop-shadow(1px 3px 3px black);
+    filter: drop-shadow(1px 3px 3px black);
 }

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -8,9 +8,10 @@
 }
 
 .obsidian-leaflet-settings .coffee {
-    width: 60%;
+    border-top: 1px solid var(--background-modifier-border);
+    width: 100%;
     color: var(--text-faint);
-    margin: 1rem auto;
+    padding: 1rem;
     text-align: center;
 }
 .obsidian-leaflet-settings .coffee img {
@@ -22,7 +23,6 @@
 }
 
 .additional-markers-container {
-    border-bottom: 1px solid var(--background-modifier-border);
     border-top: 1px solid var(--background-modifier-border);
     padding: 18px 0 0 0;
 }
@@ -64,6 +64,7 @@
 }
 
 .marker-creation-modal {
+    padding-top: 18px;
     display: grid;
     grid-template-columns: 75% 1fr;
     grid-template-rows: 1fr;
@@ -72,6 +73,15 @@
 
 .marker-creation-modal .setting-item {
     border-top: none;
+}
+
+.icon-display {
+    margin-block: 1em auto;
+    line-height: 0;
+}
+
+.icon-display canvas {
+    width: 100%;
 }
 
 .markers {

--- a/src/modals/settings.ts
+++ b/src/modals/settings.ts
@@ -25,8 +25,8 @@ export class CreateMarkerModal extends Modal {
     marker: Icon;
     tempMarker: Icon;
     plugin: ObsidianLeaflet;
-    canvas: HTMLCanvasElement;
     saved: boolean = false;
+    canvas: HTMLCanvasElement;
     constructor(app: App, plugin: ObsidianLeaflet, marker: Icon) {
         super(app);
         this.marker = marker;
@@ -172,30 +172,31 @@ export class CreateMarkerModal extends Modal {
             reader.onloadend = (evt) => {
                 var image = new Image();
                 image.onload = () => {
-                    // Resize the image
-                    const canvas = (this.canvas = createEl("canvas")),
-                        max_size = 24;
+                    this.canvas = iconDisplay.createEl("canvas");
+                    this.canvas.style.width = "100%";
+                    this.canvas.style.height = "100%";
+                    this.canvas.width = this.canvas.offsetWidth;
+                    this.canvas.height = this.canvas.offsetHeight;
                     let width = image.width,
                         height = image.height;
-                    if (width > height) {
-                        if (width > max_size) {
-                            height *= max_size / width;
-                            width = max_size;
+                    if (width < height) {
+                        if (width > this.canvas.width) {
+                            height *= this.canvas.width / width;
+                            width = this.canvas.width;
                         }
                     } else {
-                        if (height > max_size) {
-                            width *= max_size / height;
-                            height = max_size;
+                        if (height > this.canvas.height) {
+                            width *= this.canvas.height / height;
+                            height = this.canvas.height;
                         }
                     }
-                    canvas.width = width;
-                    canvas.height = height;
-                    canvas
+                    this.canvas
                         .getContext("2d")
                         .drawImage(image, 0, 0, width, height);
 
                     this.tempMarker.isImage = true;
-                    this.tempMarker.imageUrl = canvas.toDataURL("image/png");
+                    this.tempMarker.imageUrl =
+                        this.canvas.toDataURL("image/png");
 
                     this.display();
                 };
@@ -457,16 +458,33 @@ export class CreateMarkerModal extends Modal {
 
         if (this.tempMarker.isImage) {
             if (!this.canvas) {
-                this.canvas = createEl("canvas");
+                this.canvas = iconDisplay.createEl("canvas");
                 let image = new Image();
                 image.src = this.tempMarker.imageUrl;
-                this.canvas.width = image.width;
-                this.canvas.height = image.height;
+                this.canvas.style.width = "100%";
+                this.canvas.style.height = "100%";
+                this.canvas.width = this.canvas.offsetWidth;
+                this.canvas.height = this.canvas.offsetHeight;
+
+                let width = image.width,
+                    height = image.height;
+                if (width < height) {
+                    if (width > this.canvas.width) {
+                        height *= this.canvas.width / width;
+                        width = this.canvas.width;
+                    }
+                } else {
+                    if (height > this.canvas.height) {
+                        width *= this.canvas.height / height;
+                        height = this.canvas.height;
+                    }
+                }
                 this.canvas
                     .getContext("2d")
-                    .drawImage(image, 0, 0, image.width, image.height);
+                    .drawImage(image, 0, 0, width - 4, height - 4);
+            } else {
+                iconDisplay.appendChild(this.canvas);
             }
-            iconDisplay.appendChild(this.canvas);
         }
 
         add.addButton((button: ButtonComponent): ButtonComponent => {

--- a/src/modals/settings.ts
+++ b/src/modals/settings.ts
@@ -34,6 +34,7 @@ export class CreateMarkerModal extends Modal {
 
         this.tempMarker = { ...this.marker };
         if (!this.tempMarker.tags) this.tempMarker.tags = [];
+        this.containerEl.addClass("leaflet-settings-modal");
     }
     get data() {
         return this.plugin.data;

--- a/src/modals/settings.ts
+++ b/src/modals/settings.ts
@@ -44,18 +44,14 @@ export class CreateMarkerModal extends Modal {
         containerEl.empty();
 
         let createNewMarker = containerEl.createDiv();
-        createNewMarker.addClass("additional-markers-container");
-        //new Setting(createNewMarker).setHeading().setName("Create New Marker");
 
         let iconDisplayAndSettings = createNewMarker.createDiv();
         iconDisplayAndSettings.addClass("marker-creation-modal");
         let iconSettings = iconDisplayAndSettings.createDiv();
-        let iconDisplay = iconDisplayAndSettings.createDiv();
+        let iconDisplay = iconDisplayAndSettings.createDiv("icon-display");
 
         let typeTextInput: TextComponent;
-        let markerName = new Setting(
-            this.tempMarker.isImage ? createNewMarker : iconSettings
-        )
+        let markerName = new Setting(iconSettings)
             .setName(t("Marker Name"))
             .addText((text) => {
                 typeTextInput = text
@@ -90,9 +86,7 @@ export class CreateMarkerModal extends Modal {
             });
 
         let iconTextInput: TextComponent;
-        let iconName = new Setting(
-            this.tempMarker.isImage ? createNewMarker : iconSettings
-        )
+        let iconName = new Setting(iconSettings)
             .setName(t("Icon Name"))
             .setDesc(t("Font Awesome icon name (e.g. map-marker)."))
             .addText((text) => {
@@ -155,7 +149,7 @@ export class CreateMarkerModal extends Modal {
                 accept: "image/*"
             }
         });
-        new Setting(this.tempMarker.isImage ? createNewMarker : iconSettings)
+        new Setting(iconSettings)
             .setName(t("Use Image for Icon"))
             .addButton((b) => {
                 b.setButtonText(t("Upload Image")).setTooltip(
@@ -471,7 +465,7 @@ export class CreateMarkerModal extends Modal {
                     .getContext("2d")
                     .drawImage(image, 0, 0, image.width, image.height);
             }
-            add.infoEl.appendChild(this.canvas);
+            iconDisplay.appendChild(this.canvas);
         }
 
         add.addButton((button: ButtonComponent): ButtonComponent => {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -120,7 +120,7 @@ export const setValidationError = function (
             mDiv = createDiv({ cls: "invalid-feedback" });
         }
         mDiv.innerText = message;
-        mDiv.insertAfter(textInput.inputEl);
+        textInput.inputEl.parentNode.appendChild(mDiv);
     }
 };
 export const removeValidationError = function (textInput: TextComponent) {


### PR DESCRIPTION
functional fixes (via the change in src/utils/utils.ts)
* markername / iconname inputs no longer disappear when empty
* markername / iconname inputs now show errors correctly

visual fixes (via the changes in src/modals/settings.ts / main.css):
* remove 2px "double borders" between some settings
* remove unnecessary borders at the top/bottom of "create/edit marker" dialog
* show big preview of images used as markers