### PR TITLE
Define custom marker types in json files

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ On real-world maps, only `unit: ` is required. It will attempt to scale the meas
 
 New markers can be added to the map by right clicking.
 
-If any additional marker types have been created in the settings, a list will appear to choose from.
+If any additional marker types have been created in plugin settings or a `markers.json` file in the same directory, a list will appear to choose from.
 
 Once a marker has been created, it can be dragged to a different location.
 
@@ -871,6 +871,10 @@ Adding a new marker displays a new window, where the new marker parameters can b
 | Associated Tags | Immutable markers will use this marker type if the file has this tag _and `mapmarker` is not set_.   |
 
 If layer icon is on, the icon be moved around the base icon by clicking and dragging, to customize where the icon is layered. If <kbd>Shift</kbd> is held while moving the icon, it will snap to the midlines.
+
+#### Creating local marker types
+
+New markers can also be defined in a `markers.json` file. These marker types will be available to any notes in the same directory as the json file. The json file should contain an array of Icon objects, See the [Icon interface](https://github.com/javalent/obsidian-leaflet/blob/1fa4c237deceff1def883872fdad3822f9bff560/types/saved.d.ts#L7) for details.
 
 #### Using an Image as a Marker Icon
 

--- a/src/layer/marker.ts
+++ b/src/layer/marker.ts
@@ -204,8 +204,8 @@ export class Marker extends Layer<DivIconMarker> {
     ) {
         super();
 
-        const marker = this.map.plugin.getIconForType(type);
-        if (!marker) {
+        const markerIcon = this.map.markerIcons.get(type) ?? this.map.markerIcons.get('default');
+        if (!markerIcon) {
             new Notice(
                 t(
                     "Leaflet: Could not create icon for %1 - does this type exist in settings?",
@@ -214,6 +214,7 @@ export class Marker extends Layer<DivIconMarker> {
             );
             return;
         }
+        const marker = markerIcon.markerIcon;
         const icon = markerDivIcon(this.map.plugin.parseIcon(marker));
         this.leafletInstance = divIconMarker(
             loc,
@@ -251,10 +252,8 @@ export class Marker extends Layer<DivIconMarker> {
 
         this.link = link;
 
-        const markerIcon = this.map.plugin.getIconForType(this.type);
-
-        this.minZoom = minZoom ?? markerIcon?.minZoom ?? null;
-        this.maxZoom = maxZoom ?? markerIcon?.maxZoom ?? null;
+        this.minZoom = minZoom ?? marker?.minZoom ?? null;
+        this.maxZoom = maxZoom ?? marker?.maxZoom ?? null;
 
         this.checkAndAddToMap();
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -332,8 +332,8 @@ export default class ObsidianLeaflet extends Plugin {
             params,
             source
         );
-        const map = renderer.map;
-
+        
+        const map = await renderer.getMap();
         this.registerMapEvents(map);
 
         ctx.addChild(renderer);

--- a/src/main.ts
+++ b/src/main.ts
@@ -636,6 +636,7 @@ export default class ObsidianLeaflet extends Plugin {
             markerIcon: icon
         };
     }
+
     public generateMarkerMarkup(
         markers: Icon[] = this.data.markerIcons
     ): MarkerIcon[] {
@@ -661,6 +662,22 @@ export default class ObsidianLeaflet extends Plugin {
         });
 
         return ret;
+    }
+
+    public async getLocalFileMarkers(file: TFile, markerFileName = "markers.json"): Promise<MarkerIcon[]> {
+        const markerFilePath = `${file.parent.path}/${markerFileName}`;
+        const markerFile = this.app.vault.getAbstractFileByPath(markerFilePath);
+        const markers: MarkerIcon[] = [];
+        if (markerFile instanceof TFile) {
+            const markerJson = await this.app.vault.read(markerFile);
+            try {
+                const icons = JSON.parse(markerJson);
+                markers.push(...icons.map((i: Icon) => this.parseIcon(i)))
+            } catch {
+                console.error(`Badly formatted marker file ${markerFilePath}`);
+            }
+        }
+        return markers;
     }
 
     public getIconForTag(tags: Set<string>) {

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -87,7 +87,6 @@ export abstract class BaseMap extends Events implements BaseMapDefinition {
 
     CRS: L.CRS;
     distanceDisplay: DistanceDisplay;
-    localMarkerTypes: MarkerIcon[] = [];
 
     private escapeScope: Scope;
 
@@ -322,7 +321,7 @@ export abstract class BaseMap extends Events implements BaseMapDefinition {
     mapLayers: LayerGroup<L.TileLayer | L.ImageOverlay>[] = [];
     get markerIcons(): Map<string, MarkerIcon> {
         return new Map(
-            [...this.plugin.markerIcons, ...this.localMarkerTypes].map((markerIcon) => [
+            [...this.plugin.markerIcons, ...this.options.localMarkerTypes ?? []].map((markerIcon) => [
                 markerIcon.type,
                 markerIcon
             ])

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -321,7 +321,7 @@ export abstract class BaseMap extends Events implements BaseMapDefinition {
     mapLayers: LayerGroup<L.TileLayer | L.ImageOverlay>[] = [];
     get markerIcons(): Map<string, MarkerIcon> {
         return new Map(
-            [...this.plugin.markerIcons, ...this.options.localMarkerTypes ?? []].map((markerIcon) => [
+            [...this.plugin.markerIcons, ...(this.options.localMarkerTypes ?? [])].map((markerIcon) => [
                 markerIcon.type,
                 markerIcon
             ])

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -87,6 +87,7 @@ export abstract class BaseMap extends Events implements BaseMapDefinition {
 
     CRS: L.CRS;
     distanceDisplay: DistanceDisplay;
+    localMarkerTypes: MarkerIcon[] = [];
 
     private escapeScope: Scope;
 
@@ -321,7 +322,7 @@ export abstract class BaseMap extends Events implements BaseMapDefinition {
     mapLayers: LayerGroup<L.TileLayer | L.ImageOverlay>[] = [];
     get markerIcons(): Map<string, MarkerIcon> {
         return new Map(
-            this.plugin.markerIcons.map((markerIcon) => [
+            [...this.plugin.markerIcons, ...this.localMarkerTypes].map((markerIcon) => [
                 markerIcon.type,
                 markerIcon
             ])

--- a/src/modals/context.ts
+++ b/src/modals/context.ts
@@ -5,7 +5,7 @@ import type {
     Marker,
     TooltipDisplay,
     BaseMapType
-} from "../types";
+} from "../../types";
 
 import { PathSuggestionModal } from "./path";
 import { CommandSuggestionModal } from "./command";
@@ -60,9 +60,7 @@ export class MarkerContextModal extends Modal {
                     let newMarker =
                         value == "default"
                             ? this.map.data.defaultMarker
-                            : this.map.data.markerIcons.find(
-                                  (m) => m.type == value
-                              );
+                            : this.map.markerIcons.get(value);
                     this.tempMarker.type = newMarker.type;
                 });
             });

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -75,6 +75,7 @@ export class LeafletRenderer extends MarkdownRenderChild {
     loader: Loader = new Loader(this.plugin.app);
     resize: ResizeObserver;
     map: BaseMapType;
+    private mapBuilt: Promise<void>;
     verbose: boolean;
     parentEl: HTMLElement;
     options: LeafletMapOptions;
@@ -194,8 +195,7 @@ export class LeafletRenderer extends MarkdownRenderChild {
                 this.map.leafletInstance.invalidateSize();
             }
         });
-
-        this.buildMap();
+        this.mapBuilt = this.buildMap();
 
         this.resize.observe(this.containerEl);
     }
@@ -254,7 +254,17 @@ export class LeafletRenderer extends MarkdownRenderChild {
         this.map.leafletInstance.invalidateSize();
     }
 
-    async buildMap() {
+    /**
+     * Use this to get the map instance instead of renderer.map when it might not be defined yet
+     */
+    async getMap(): Promise<BaseMapType> {
+        await this.mapBuilt;
+        return this.map;
+    }
+
+    async buildMap(): Promise<void> {
+        this.options.localMarkerTypes = await this.plugin.getLocalFileMarkers(this.file);
+
         if (this.options.type === "real") {
             this.map = new RealMap(this, this.options);
         } else {
@@ -283,8 +293,6 @@ export class LeafletRenderer extends MarkdownRenderChild {
             this.map.log(`Loading layer data for ${this.map.id}.`);
             this.loader.loadImage(this.map.id, [this.options.layers[0]]);
         }
-
-        this.map.localMarkerTypes = await this.plugin.getLocalFileMarkers(this.file);
 
         this.map.on("removed", () => this.resize.disconnect());
         this.map.on(
@@ -341,6 +349,7 @@ export class LeafletRenderer extends MarkdownRenderChild {
     }
 
     async onload() {
+        await this.mapBuilt;
         this.map.log("MarkdownRenderChild loaded. Appending map.");
         this.containerEl.appendChild(this.map.contentEl);
 

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -284,6 +284,8 @@ export class LeafletRenderer extends MarkdownRenderChild {
             this.loader.loadImage(this.map.id, [this.options.layers[0]]);
         }
 
+        this.map.localMarkerTypes = await this.plugin.getLocalFileMarkers(this.file);
+
         this.map.on("removed", () => this.resize.disconnect());
         this.map.on(
             "should-save",

--- a/types/map.d.ts
+++ b/types/map.d.ts
@@ -196,6 +196,7 @@ declare abstract class BaseMap /* <
     leafletInstance: L.Map;
     mapLayers: LayerGroup<L.TileLayer | L.ImageOverlay>[];
 
+    localMarkerTypes: MarkerIcon[];
     markers: Marker[];
     get markerIcons(): Map<string, MarkerIcon>;
     get markerTypes(): string[];

--- a/types/map.d.ts
+++ b/types/map.d.ts
@@ -68,6 +68,8 @@ export interface LeafletMapOptions {
     geojsonColor?: string;
     gpxColor?: string;
 
+    localMarkerTypes?: MarkerIcon[];
+
     hasAdditional?: boolean;
     height?: string;
     width?: string;
@@ -196,7 +198,6 @@ declare abstract class BaseMap /* <
     leafletInstance: L.Map;
     mapLayers: LayerGroup<L.TileLayer | L.ImageOverlay>[];
 
-    localMarkerTypes: MarkerIcon[];
     markers: Marker[];
     get markerIcons(): Map<string, MarkerIcon>;
     get markerTypes(): string[];

--- a/types/marker.d.ts
+++ b/types/marker.d.ts
@@ -1,6 +1,6 @@
 import { Icon, TooltipDisplay } from ".";
 import { MarkerDivIcon } from "./map";
-import type { Marker as MarkerDefinition } from "../layer/marker";
+import type { Marker as MarkerDefinition } from "../src/layer/marker";
 
 export type Marker = MarkerDefinition;
 export interface MarkerIcon {


### PR DESCRIPTION
Slightly WIP, there's one issue I've yet to solve. Was hoping to get some feedback on this. First, a summary:

- when the renderer builds the map, it now additionally checks for a json file in the same directory. Currently that file is hardcoded to be named `markers.json`
- The `markers.json` file should be an array of marker types with the exact same syntax as the markers stored in plugin settings
- These markers otherwise function the same as the normally defined markers

Still to-do / feedback requested:
- [x] Document the new feature.
- [x] Marker file name setting? I wasn't sure if this would be overkill.
- [x] Fix the bug described below.

Currently, the marker file is read *after* the map is created:

```typescript
    // renderer.ts
    async buildMap() {
        if (this.options.type === "real") {
            this.map = new RealMap(this, this.options);
        } else {
            this.map = new ImageMap(this, this.options);
            // ...
        }
        this.map.localMarkerTypes = await this.plugin.getLocalFileMarkers(this.file);
```

This causes markers of types defined in the json file to not render correctly until they are edited or otherwise re-rendered, since the marker types aren't available when the map is first constructed. Originally I tried to read the file before creating the map and then passing any additional markers as one of the option parameters, but something about awaiting ANY async call before the map is created causes the plugin to error out. This code throws this error:

```typescript
    // renderer.ts
    async buildMap() {
        const somePromise = Promise.resolve('some value');
        const theValue = await somePromise;
        if (this.options.type === "real") {
            this.map = new RealMap(this, this.options);
        } else {
            this.map = new ImageMap(this, this.options);
```

```
plugin:obsidian-leaflet-plugin:2 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'contentEl')
    at uo.registerMapEvents (plugin:obsidian-leaflet-plugin:2:1558633)
    at uo.postprocessor (plugin:obsidian-leaflet-plugin:2:1556132)
    at t.initDOM (app.js:1:1406811)
    at t.toDOM (app.js:1:1403089)
    at t.sync (app.js:1:389594)
    at e.sync (app.js:1:365245)
    at app.js:1:406709
    at e.ignore (app.js:1:480071)
    at t.updateInner (app.js:1:406505)
    at t.update (app.js:1:406266)
```

I've really got no clue why awaiting any promise (even an already resolved promise) would cause this, was hoping to get a second pair of eyes on that. My assumption is that somewhere someone is trying to access the map synchronously and introducing the await causes it to be instantiated in a later cycle. But I wasn't able to find the source of the issue.