### PR TITLE
Fixes Problem relating imagemaps and messed up bounds when returning from markdown view

### DIFF
--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -352,6 +352,7 @@ export class LeafletRenderer extends MarkdownRenderChild {
         await this.mapBuilt;
         this.map.log("MarkdownRenderChild loaded. Appending map.");
         this.containerEl.appendChild(this.map.contentEl);
+        this.map.leafletInstance.invalidateSize();
 
         if (!this.parentEl.contains(this.containerEl)) {
             this.map.log(

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -352,6 +352,8 @@ export class LeafletRenderer extends MarkdownRenderChild {
         await this.mapBuilt;
         this.map.log("MarkdownRenderChild loaded. Appending map.");
         this.containerEl.appendChild(this.map.contentEl);
+        // added because bound's get somehow messed up in the render process and only normalize when calling this.
+        // haven't found the cause of the issue, but that seems to work around it. see issue #412
         this.map.leafletInstance.invalidateSize();
 
         if (!this.parentEl.contains(this.containerEl)) {


### PR DESCRIPTION
## Pull Request Description

Fixes an issue where the bound's on the leaflet map instance gets messed up.

## Related Issues

Fixes #412

## Checklist

- [ ] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [ ] All tests (if applicable) have passed successfully.
- [ ] I have run linters and fixed any issues.
- [ ] I have checked for any potential security issues or vulnerabilities.

BEGIN_COMMIT_OVERRIDE
fix: invalidate map size to prevent incorrect starting positions in some situations
END_COMMIT_OVERRIDE
