### PR TITLE
fixed off by 1 error, otherwise geoJson Search always goes at least 2 levels deep...

### DIFF
--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -1344,7 +1344,7 @@ export class LeafletRenderer extends MarkdownRenderChild {
         if (path[0] == ".") {
             path = sub + path.substring(1);
         }
-        let depth = path.endsWith("/") ? 2 : Infinity;
+        let depth = path.endsWith("/") ? 1 : Infinity;
         while (path.endsWith("/")) {
             path = path.substring(0, path.length - 1);
             ++depth;


### PR DESCRIPTION
...even when only a single / is appended.

## Pull Request Description

Hi, this PR fixes an off-by-1 error that leads to extremely long loading times (hours),
when you have many geojson Files in deeper nested directories. 

## Changes Proposed

By reducing the initial Counter to 1 you can limit the depth to just the given Directory. 
I have tested it with all my Repos, e.g. this: https://github.com/SpocWiki/Europe-Germany 

## Related Issues

Breaking change: 
Of course this means that everyone needs to append a single '/' to get the results as before. 

Fixes #Issue_Number

## Checklist

<!-- Make sure to check the items below before submitting your pull request -->

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

## Screenshots (if applicable)

## Additional Notes

none