### PR TITLE
feat: Display track names extracted from GPX metadata instead of 'GPX…

### DIFF
--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -614,9 +614,10 @@ export abstract class BaseMap extends Events implements BaseMapDefinition {
                     );
                     gpxInstance.show();
                     gpxInstance.leafletInstance.addTo(this.gpxLayer);
+                    const trackname = gpxInstance.geojson.features[0].title ?? "GPX";
                     this.layerControl.addOverlay(
                         gpxInstance.leafletInstance,
-                        alias ?? `GPX ${added + 1}`
+                        alias ?? `${trackname} ${added + 1}`
                     );
                     added++;
                 } catch (e) {


### PR DESCRIPTION
…' in the layers control.

## Pull Request Description

 Display track names extracted from GPX metadata instead of 'GPX in the layers control.

## Checklist

<!-- Make sure to check the items below before submitting your pull request -->

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [ ] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [ ] All tests (if applicable) have passed successfully.
- [ ] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

## Screenshots (if applicable)

![Pasted image 20240716115420](https://github.com/user-attachments/assets/f982efad-9b2c-40b6-a4e9-e9f1727901b5)
![Pasted image 20240817162253](https://github.com/user-attachments/assets/f00f4128-ac29-438a-9149-84e332a4d12b)
