### PR TITLE
feat: add configuration to default all image layers on or off

### DIFF
--- a/src/l10n/locales/en.ts
+++ b/src/l10n/locales/en.ts
@@ -110,6 +110,7 @@ export default {
     Hover: "Hover",
     Never: "Never",
     "Display Note Preview": "Display Note Preview",
+    "Default Image Layer On": "Default Image Layer On",
     "Markers linked to notes will show a note preview when hovered.":
         "Markers linked to notes will show a note preview when hovered.",
     "Display Overlay Tooltips": "Display Overlay Tooltips",

--- a/src/l10n/locales/zh_CN.ts
+++ b/src/l10n/locales/zh_CN.ts
@@ -111,6 +111,7 @@ export default {
     Hover: "悬停",
     Never: "从不",
     "Display Note Preview": "显示笔记预览",
+    "Default Image Layer On": "默认图像层打开",
     "Markers linked to notes will show a note preview when hovered.":
         "当鼠标悬停在已经关联笔记的标记上时，会显示关联笔记的预览界面",
     "Display Overlay Tooltips": "显示叠加层提示",

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -664,6 +664,7 @@ export abstract class BaseMap extends Events implements BaseMapDefinition {
                     });
 
                     this.layerControl.addOverlay(image, overlay.alias);
+                    this.data.imageLayerDefaultOn && this.leafletInstance.addLayer(image);
                 }
             });
         }

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -627,6 +627,22 @@ export class ObsidianLeafletSettingTab extends PluginSettingTab {
                 })
             );
         new Setting(containerEl)
+            .setName(t("Default Image Layers On"))
+            .setDesc(
+                t(
+                    "All image layers will default to visible instead of hidden"
+                )
+            )
+            .addToggle((toggle) =>
+                toggle.setValue(this.data.imageLayerDefaultOn).onChange(async (v) => {
+                    this.data.imageLayerDefaultOn = v;
+
+                    await this.plugin.saveSettings();
+
+                    this.display();
+                })
+            );
+        new Setting(containerEl)
             .setName(t("Display Overlay Tooltips"))
             .setDesc(t("Overlay tooltips will display when hovered."))
             .addToggle((toggle) =>

--- a/types/saved.d.ts
+++ b/types/saved.d.ts
@@ -37,6 +37,7 @@ export interface ObsidianAppData {
     lat: number;
     long: number;
     notePreview: boolean;
+    imageLayerDefaultOn: boolean;
     layerMarkers: boolean;
     previousVersion: string;
     version: {


### PR DESCRIPTION
## Pull Request Description
I would like to add a configuration that defaults all image layers visible on map startup. This is because I'm using image layers extensively to overlay real-world maps with fun historical maps for my games. It's really frustrating that every time I toggle between pages, all the image layers disappear, and I have to re-enable them one at a time. This will preserve the current functionality for users, but make my use case much more convenient (I imagine I'm not the only one using lots of layers!)

## Changes Proposed
- [ ] Add setting imageLayerDefaultOn (defaults to false)
- [ ] When imageLayerDefaultOn is true, default all layers to selected on map startup