### PR TITLE
fix: apply zoomMarkers on first render

### DIFF
--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -214,6 +214,12 @@ export abstract class BaseMap extends Events implements BaseMapDefinition {
         this.leafletInstance.on("click", (evt: L.LeafletMouseEvent) =>
             this.handleMapClick(evt)
         );
+        this.on('rendered', () => {
+            if (this.options.zoomMarkers) {
+                this.log(`Zooming to markers.`);
+                this.zoomAllMarkers();
+            }
+        })
 
         this.on("first-layer-ready", () => {
             this.addFeatures();
@@ -250,12 +256,6 @@ export abstract class BaseMap extends Events implements BaseMapDefinition {
             this.featureLayer.addTo(this.currentGroup.group);
             this.currentGroup.group.addTo(this.leafletInstance);
             this.tileOverlayLayer.addTo(this.leafletInstance);
-
-            if (this.options.zoomMarkers) {
-                this.log(`Zooming to markers.`);
-
-                this.zoomAllMarkers();
-            }
         });
 
         this.leafletInstance.on(


### PR DESCRIPTION
## Pull Request Description
`zoomMarkers` doesn't apply when first rendering the map. The zoom level is being calculated before the map's initial, which results in it defaulting to `1`.

## Changes Proposed
Wait until the map is fully rendered before applying the `zoomMarkers` configuration option.

## Related Issues

Fixes #466 

## Checklist

<!-- Make sure to check the items below before submitting your pull request -->

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

## Screenshots (if applicable)

Before
<img width="734" alt="image" src="https://github.com/user-attachments/assets/a233221c-20de-4e2d-b670-3c59e193d6b0" />

After:
<img width="765" alt="image" src="https://github.com/user-attachments/assets/8ea8bcca-1cc4-466a-9be8-b7145e7d2372" />


## Additional Notes

<!-- Any additional information or context you want to provide about the pull request -->
